### PR TITLE
Add .gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+poke_images/*.png


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude `__pycache__`, compiled Python files, and images under `poke_images`

## Testing
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6852ade62e8c832d9875c63f12d35608